### PR TITLE
Allow labels to take on integer values represented by the string type.

### DIFF
--- a/spade_anomaly_detection/data_loader_test.py
+++ b/spade_anomaly_detection/data_loader_test.py
@@ -62,6 +62,7 @@ class DataLoaderTest(tf.test.TestCase, parameterized.TestCase):
         label_col_name='label',
         positive_data_value=5,
         negative_data_value=3,
+        labels_are_strings=False,
         unlabeled_data_value=-100,
         positive_threshold=5,
         negative_threshold=95,

--- a/spade_anomaly_detection/occ_ensemble.py
+++ b/spade_anomaly_detection/occ_ensemble.py
@@ -209,14 +209,16 @@ class GmmEnsemble:
         'negative_indices': negative_indices
     }
 
-  def pseudo_label(self,
-                   features: np.ndarray,
-                   labels: np.ndarray,
-                   positive_data_value: int,
-                   negative_data_value: Optional[int],
-                   unlabeled_data_value: int,
-                   alpha: float = 1.0,
-                   verbose: Optional[bool] = False) -> Sequence[np.ndarray]:
+  def pseudo_label(
+      self,
+      features: np.ndarray,
+      labels: np.ndarray,
+      positive_data_value: str | int,
+      negative_data_value: str | int | None,
+      unlabeled_data_value: str | int,
+      alpha: float = 1.0,
+      verbose: Optional[bool] = False,
+  ) -> Sequence[np.ndarray]:
     """Labels unlabeled data using the trained ensemble of OCCs.
 
     Args:
@@ -270,13 +272,15 @@ class GmmEnsemble:
         negative_features,
     ],
                                   axis=0)
-    new_labels = np.concatenate([
-        np.ones(len(new_positive_indices)),
-        np.zeros(len(new_negative_indices)),
-        np.ones(len(original_positive_idx)),
-        np.zeros(len(original_negative_idx))
-    ],
-                                axis=0)
+    new_labels = np.concatenate(
+        [
+            np.full(len(new_positive_indices), positive_data_value),
+            np.full(len(new_negative_indices), negative_data_value),
+            np.full(len(original_positive_idx), positive_data_value),
+            np.full(len(original_negative_idx), negative_data_value),
+        ],
+        axis=0,
+    )
     weights = np.concatenate([
         np.repeat(alpha, len(new_positive_indices)),
         np.repeat(alpha, len(new_negative_indices)),

--- a/spade_anomaly_detection/parameters_test.py
+++ b/spade_anomaly_detection/parameters_test.py
@@ -46,9 +46,9 @@ class ParametersTest(tf.test.TestCase):
             data_input_gcs_uri='gs://some_bucket/some_data_input_path',
             output_gcs_uri='gs://some_bucket/some_path',
             label_col_name='y',
-            positive_data_value=1,
-            negative_data_value=0,
-            unlabeled_data_value=-1,
+            positive_data_value='1',
+            negative_data_value='0',
+            unlabeled_data_value='-1',
         )
     with self.subTest(name='no_input_sources_specified'):
       with self.assertRaises(ValueError):
@@ -58,9 +58,9 @@ class ParametersTest(tf.test.TestCase):
             data_input_gcs_uri=None,
             output_gcs_uri='gs://some_bucket/some_path',
             label_col_name='y',
-            positive_data_value=1,
-            negative_data_value=0,
-            unlabeled_data_value=-1,
+            positive_data_value='1',
+            negative_data_value='0',
+            unlabeled_data_value='-1',
         )
 
   def test_equal_data_value_parameter_raises(self):
@@ -71,9 +71,23 @@ class ParametersTest(tf.test.TestCase):
           data_input_gcs_uri=None,
           output_gcs_uri='gs://some_bucket/some_path',
           label_col_name='y',
+          positive_data_value='1',
+          negative_data_value='0',
+          unlabeled_data_value='0',
+      )
+
+  def test_labels_are_strings_discrepancy_raises(self):
+    with self.assertRaises(TypeError):
+      _ = parameters.RunnerParameters(
+          train_setting=parameters.TrainSetting.PNU,
+          input_bigquery_table_path='some_project.some_dataset.some_table',
+          data_input_gcs_uri=None,
+          output_gcs_uri='gs://some_bucket/some_path',
+          label_col_name='y',
+          labels_are_strings=True,
           positive_data_value=1,
           negative_data_value=0,
-          unlabeled_data_value=0,
+          unlabeled_data_value=-1,
       )
 
 

--- a/spade_anomaly_detection/performance_test.py
+++ b/spade_anomaly_detection/performance_test.py
@@ -34,9 +34,9 @@ of the entire SPADE algorithm that was not caught during the unit testing of
 individual modules and functions.
 """
 
-
 from unittest import mock
 
+from absl.testing import parameterized
 from spade_anomaly_detection import csv_data_loader
 from spade_anomaly_detection import data_loader
 from spade_anomaly_detection import parameters
@@ -66,6 +66,7 @@ class PerformanceTestOnBQData(tf.test.TestCase):
         positive_data_value=1,
         negative_data_value=0,
         unlabeled_data_value=-1,
+        labels_are_strings=False,
         positive_threshold=10,
         negative_threshold=90,
         test_label_col_name='y',
@@ -240,7 +241,7 @@ class PerformanceTestOnBQData(tf.test.TestCase):
     self.assertAlmostEqual(auc, 0.9178, delta=0.02)
 
 
-class PerformanceTestOnCSVData(tf.test.TestCase):
+class PerformanceTestOnCSVData(tf.test.TestCase, parameterized.TestCase):
 
   def setUp(self):
     super().setUp()
@@ -262,6 +263,7 @@ class PerformanceTestOnCSVData(tf.test.TestCase):
         positive_data_value=1,
         negative_data_value=0,
         unlabeled_data_value=-1,
+        labels_are_strings=False,
         positive_threshold=10,
         negative_threshold=90,
         test_label_col_name='y',
@@ -399,8 +401,22 @@ class PerformanceTestOnCSVData(tf.test.TestCase):
         )
     )
 
-  def test_spade_auc_performance_pnu_single_batch(self):
+  @parameterized.named_parameters([
+      ('labels_are_ints', False, 1, 0, -1),
+      ('labels_are_strings', True, '1', '0', '-1'),
+  ])
+  def test_spade_auc_performance_pnu_single_batch(
+      self,
+      labels_are_strings: bool,
+      positive_data_value: str | int,
+      negative_data_value: str | int,
+      unlabeled_data_value: str | int,
+  ):
     self.runner_parameters.train_setting = parameters.TrainSetting.PNU
+    self.runner_parameters.labels_are_strings = labels_are_strings
+    self.runner_parameters.positive_data_value = positive_data_value
+    self.runner_parameters.negative_data_value = negative_data_value
+    self.runner_parameters.unlabeled_data_value = unlabeled_data_value
     self.runner_parameters.positive_threshold = 0.1
     self.runner_parameters.negative_threshold = 95
     self.runner_parameters.alpha = 0.1
@@ -433,8 +449,22 @@ class PerformanceTestOnCSVData(tf.test.TestCase):
     # performance seen on the ~580k row Coertype dataset in the PNU setting.
     self.assertAlmostEqual(auc, 0.9755, delta=0.02)
 
-  def test_spade_auc_performance_pu_single_batch(self):
+  @parameterized.named_parameters([
+      ('labels_are_ints', False, 1, 0, -1),
+      ('labels_are_strings', True, '1', '0', '-1'),
+  ])
+  def test_spade_auc_performance_pu_single_batch(
+      self,
+      labels_are_strings: bool,
+      positive_data_value: str | int,
+      negative_data_value: str | int,
+      unlabeled_data_value: str | int,
+  ):
     self.runner_parameters.train_setting = parameters.TrainSetting.PU
+    self.runner_parameters.labels_are_strings = labels_are_strings
+    self.runner_parameters.positive_data_value = positive_data_value
+    self.runner_parameters.negative_data_value = negative_data_value
+    self.runner_parameters.unlabeled_data_value = unlabeled_data_value
     self.runner_parameters.positive_threshold = 10
     self.runner_parameters.negative_threshold = 50
     self.runner_parameters.labeling_and_model_training_batch_size = (

--- a/spade_anomaly_detection/supervised_model_test.py
+++ b/spade_anomaly_detection/supervised_model_test.py
@@ -29,34 +29,42 @@
 
 """Tests for supervised models."""
 
+
 from unittest import mock
 
+from absl.testing import parameterized
 from spade_anomaly_detection import data_loader
 from spade_anomaly_detection import supervised_model
-
 import tensorflow as tf
 import tensorflow_decision_forests as tfdf
 
 
-def _get_labeled_dataset() -> tf.data.Dataset:
+def _get_labeled_dataset(labels_are_strings: bool = False) -> tf.data.Dataset:
   """Loads the thyroid_labeled dataset for model performance testing.
+
+  Args:
+    labels_are_strings: Whether the labels are strings or integers.
 
   Returns:
     TensorFlow dataset with X, y split.
   """
   features, labels = data_loader.load_dataframe('thyroid_labeled')
 
-  labeled_dataset = (
-      tf.data.Dataset.from_tensor_slices((features, labels))
-      .batch(100)
-      .as_numpy_iterator()
-      .next()
-  )
+  original_dataset = tf.data.Dataset.from_tensor_slices((features, labels))
+  if labels_are_strings:
+    # Mimic the behavior of the CsvDataLoader by converting the labels to
+    # strings. The string labels are converted back to integers in the
+    # Data loader.
+    # Treat the labels as strings for testing. Note that the test dataset
+    # contains only integer labels.
+    original_dataset = original_dataset.map(lambda x, y: (x, tf.as_string(y)))
+
+  labeled_dataset = original_dataset.batch(100).as_numpy_iterator().next()
 
   return labeled_dataset
 
 
-class SupervisedModelsTest(tf.test.TestCase):
+class SupervisedModelsTest(tf.test.TestCase, parameterized.TestCase):
 
   def test_supervised_model_create_no_error(self):
     params = supervised_model.RandomForestParameters(max_depth=20)
@@ -64,28 +72,51 @@ class SupervisedModelsTest(tf.test.TestCase):
 
     self.assertEqual(model_instance.supervised_parameters.max_depth, 20)
 
+  @parameterized.named_parameters(
+      ('labels_are_integers', False),
+      ('labels_are_strings', True),
+  )
   @mock.patch.object(tfdf.keras.RandomForestModel, 'fit', autospec=True)
-  def test_train_supervised_model_no_error(self, mock_fit):
+  def test_train_supervised_model_no_error(
+      self, labels_are_strings: bool, mock_fit: mock.Mock
+  ):
     params = supervised_model.RandomForestParameters()
     model = supervised_model.RandomForestModel(parameters=params)
-    features, labels = _get_labeled_dataset()
+    features, labels = _get_labeled_dataset(labels_are_strings)
 
-    model.train(features=features, labels=labels)
+    # The CsvDataLoader converts the labels to integers, while the BQDataLoader
+    # assumes that the labels are integers. So for this test, convert the labels
+    # to integers here.
+    model.train(features=features, labels=labels.astype(int))
 
     mock_fit_actual_call_args = mock_fit.call_args.kwargs
 
-    expected_fit_call_args = {'x': features, 'y': labels, 'sample_weight': None}
+    # Convert the labels to integers for the expected call args.
+    expected_fit_call_args = {
+        'x': features,
+        'y': labels.astype(int),
+        'sample_weight': None,
+    }
 
     self.assertDictEqual(mock_fit_actual_call_args, expected_fit_call_args)
 
+  @parameterized.named_parameters(
+      ('labels_are_integers', False),
+      ('labels_are_strings', True),
+  )
   @mock.patch.object(tfdf.keras.RandomForestModel, 'save', autospec=True)
-  def test_model_saving_no_error(self, mock_tfdf_save):
-    job_dir = 'gs://test_bucket/test_folder/'
+  def test_model_saving_no_error(
+      self, labels_are_strings: bool, mock_tfdf_save: mock.Mock
+  ):
+    job_dir: str = 'gs://test_bucket/test_folder/'
     params = supervised_model.RandomForestParameters()
     model = supervised_model.RandomForestModel(parameters=params)
-    features, labels = _get_labeled_dataset()
+    features, labels = _get_labeled_dataset(labels_are_strings)
 
-    model.train(features=features, labels=labels)
+    # The CsvDataLoader converts the labels to integers, while the BQDataLoader
+    # assumes that the labels are integers. So for this test, convert the labels
+    # to integers here.
+    model.train(features=features, labels=labels.astype(int))
     model.save(job_dir)
 
     mock_tfdf_save.assert_called_once_with(model.supervised_model, job_dir)

--- a/spade_anomaly_detection/task.py
+++ b/spade_anomaly_detection/task.py
@@ -104,21 +104,30 @@ _LABEL_COL_NAME = flags.DEFINE_string(
     help="The name of the label column in BigQuery.",
 )
 
-_POSITIVE_DATA_VALUE = flags.DEFINE_integer(
+_LABELS_ARE_STRINGS = flags.DEFINE_bool(
+    "labels_are_strings",
+    default=True,
+    required=False,
+    help=(
+        "Set to True if the labels are strings. Otherwise the labels are ints."
+    ),
+)
+
+_POSITIVE_DATA_VALUE = flags.DEFINE_string(
     "positive_data_value",
     default=None,
     required=True,
     help="The column value used to define an anomalous (positive) data point.",
 )
 
-_NEGATIVE_DATA_VALUE = flags.DEFINE_integer(
+_NEGATIVE_DATA_VALUE = flags.DEFINE_string(
     "negative_data_value",
     default=None,
     required=True,
     help="The column value used to define a normal (negative) data point.",
 )
 
-_UNLABELED_DATA_VALUE = flags.DEFINE_integer(
+_UNLABELED_DATA_VALUE = flags.DEFINE_string(
     "unlabeled_data_value",
     default=None,
     required=True,
@@ -372,6 +381,7 @@ def main(argv: Sequence[str]) -> None:
       positive_data_value=_POSITIVE_DATA_VALUE.value,
       negative_data_value=_NEGATIVE_DATA_VALUE.value,
       unlabeled_data_value=_UNLABELED_DATA_VALUE.value,
+      labels_are_strings=_LABELS_ARE_STRINGS.value,
       positive_threshold=_POSITIVE_THRESHOLD.value,
       negative_threshold=_NEGATIVE_THRESHOLD.value,
       ignore_columns=_IGNORE_COLUMNS.value,
@@ -401,5 +411,6 @@ if __name__ == "__main__":
   try:
     app.run(main)
   except Exception as e:
+    logging.error(str(e))
     logging.shutdown()
-    raise e
+    raise


### PR DESCRIPTION
Allow labels to take on integer values represented by the string type.

This change allows the input label type to be a string containg an integer, as well as the empty string which is mapped to the unlabeled data value.

This feature is supported and tested only for the CSV data loader.

Summary:

1. dtype of label column will be str or int.
2. empty string is a legal value.
3. empty string will be internally mapped to the unlabeled value.
4. internally the map is: {'1': 1, '0': 0, '': -1, '-1': -1}.
